### PR TITLE
feat: add event propagation control with stopPropagation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,43 @@ const taskLogger = task({
 });
 ```
 
+#### Event Propagation Control with stopPropagation()
+
+Sometimes you need to prevent other event listeners from processing an event. The `stopPropagation()` method gives you fine-grained control over event flow:
+
+```typescript
+const criticalAlert = event<{
+  severity: "low" | "medium" | "high" | "critical";
+}>({
+  id: "app.events.alert",
+  meta: {
+    title: "System Alert Event",
+    description: "Emitted when system issues are detected",
+    tags: ["monitoring", "alerts"],
+  },
+});
+
+// High-priority handler that can stop propagation
+const emergencyHandler = task({
+  id: "app.tasks.emergencyHandler",
+  on: criticalAlert, // Works with global events too
+  listenerOrder: -100, // Higher priority (lower numbers run first)
+  run: async (event) => {
+    console.log(`Alert received: ${event.data.severity}`);
+
+    if (event.data.severity === "critical") {
+      console.log("🚨 CRITICAL ALERT - Activating emergency protocols");
+
+      // Stop other handlers from running
+      event.stopPropagation();
+      // Notify the on-call team, escalate, etc.
+
+      console.log("🛑 Event propagation stopped - emergency protocols active");
+    }
+  },
+});
+```
+
 ### 4. Middleware: The Interceptor Pattern Done Right
 
 Middleware wraps around your tasks and resources, adding cross-cutting concerns without polluting your business logic.

--- a/src/__tests__/globalEvents.test.ts
+++ b/src/__tests__/globalEvents.test.ts
@@ -1,5 +1,5 @@
 import { globalEvents } from "../globals/globalEvents";
-import { defineTask, defineResource } from "../define";
+import { defineTask, defineResource, defineMiddleware, defineEvent } from "../define";
 import { run } from "../run";
 
 describe("Global Events", () => {
@@ -120,5 +120,316 @@ describe("Global Events", () => {
     await run(app);
 
     expect(globalTaskOnErrorHandler).toHaveBeenCalled();
+  });
+
+  it("should ensure global event listeners get their middleware called", async () => {
+    const middlewareExecutions: string[] = [];
+    const eventHandlerExecutions: string[] = [];
+
+    // Custom event to emit
+    const customEvent = defineEvent<{ message: string }>({
+      id: "test.customEvent",
+      meta: {
+        title: "Test Event",
+        description: "Test event for middleware verification",
+        tags: ["test"],
+      },
+    });
+
+    // Middleware that logs execution
+    const testMiddleware = defineMiddleware({
+      id: "test.middleware",
+      run: async ({ next, task }) => {
+        const taskId = task?.definition?.id || "unknown";
+        middlewareExecutions.push(`middleware-before:${String(taskId)}`);
+        const result = await next(task?.input);
+        middlewareExecutions.push(`middleware-after:${String(taskId)}`);
+        return result;
+      },
+    });
+
+    // Global event listener task with middleware
+    const globalEventHandler = defineTask({
+      id: "global.event.handler",
+      on: "*", // Global listener
+      middleware: [testMiddleware],
+      run: async (event) => {
+        if (event && event.id) {
+          eventHandlerExecutions.push(`global-handler:${event.id.toString()}`);
+          // Verify the event has meta included
+          expect(event.meta).toBeDefined();
+          if (event.id === customEvent.id) {
+            expect(event.meta.title).toBe("Test Event");
+            expect(event.meta.tags).toContain("test");
+            expect(event.data.message).toBe("Hello from custom event");
+          }
+        }
+      },
+    });
+
+    // Specific event listener task with middleware
+    const specificEventHandler = defineTask({
+      id: "specific.event.handler",
+      on: customEvent,
+      middleware: [testMiddleware],
+      run: async (event) => {
+        if (event && event.id) {
+          eventHandlerExecutions.push(`specific-handler:${event.id.toString()}`);
+          expect(event.meta.title).toBe("Test Event");
+          expect(event.data.message).toBe("Hello from custom event");
+        }
+      },
+    });
+
+    // Task that emits the custom event
+    const eventEmitter = defineTask({
+      id: "event.emitter",
+      dependencies: { customEvent },
+      run: async (_, { customEvent }) => {
+        await customEvent({ message: "Hello from custom event" });
+        return "Event emitted";
+      },
+    });
+
+    const app = defineResource({
+      id: "app",
+      register: [
+        customEvent,
+        testMiddleware,
+        globalEventHandler,
+        specificEventHandler,
+        eventEmitter,
+      ],
+      dependencies: { eventEmitter },
+      async init(_, { eventEmitter }) {
+        await eventEmitter();
+      },
+    });
+
+    await run(app);
+
+    // Verify middleware was called for global event listener
+    expect(middlewareExecutions).toContain("middleware-before:global.event.handler");
+    expect(middlewareExecutions).toContain("middleware-after:global.event.handler");
+
+    // Verify middleware was called for specific event listener
+    expect(middlewareExecutions).toContain("middleware-before:specific.event.handler");
+    expect(middlewareExecutions).toContain("middleware-after:specific.event.handler");
+
+    // Verify event handlers were executed
+    expect(eventHandlerExecutions).toContain("global-handler:test.customEvent");
+    expect(eventHandlerExecutions).toContain("specific-handler:test.customEvent");
+
+    // Verify global listeners also handle other events (like global events themselves)
+    expect(eventHandlerExecutions.some(exec => 
+      exec.includes("global-handler:") && exec.includes("beforeInit")
+    )).toBe(true);
+  });
+
+  it("should support stopPropagation in event listeners", async () => {
+    const eventHandlerExecutions: string[] = [];
+
+    const testEvent = defineEvent<{ value: number }>({
+      id: "test.propagationEvent",
+      meta: {
+        title: "Propagation Test Event",
+        tags: ["propagation", "test"],
+      },
+    });
+
+    // High priority listener that stops propagation
+    const highPriorityHandler = defineTask({
+      id: "high.priority.handler",
+      on: testEvent,
+      listenerOrder: -100, // Higher priority (runs first)
+      run: async (event) => {
+        eventHandlerExecutions.push("high-priority-executed");
+        
+        if (event && event.data && event.data.value > 10) {
+          event.stopPropagation();
+          eventHandlerExecutions.push("propagation-stopped");
+        }
+      },
+    });
+
+    // Low priority listener that should be skipped when propagation is stopped
+    const lowPriorityHandler = defineTask({
+      id: "low.priority.handler",
+      on: testEvent,
+      listenerOrder: 100, // Lower priority (runs later)
+      run: async () => {
+        // This handler will only execute when propagation is NOT stopped
+        eventHandlerExecutions.push("low-priority-executed");
+      },
+    });
+
+    const eventEmitter = defineTask({
+      id: "propagation.emitter",
+      dependencies: { testEvent },
+      run: async (value: number, { testEvent }) => {
+        await testEvent({ value });
+      },
+    });
+
+    const app = defineResource({
+      id: "app",
+      register: [
+        testEvent,
+        highPriorityHandler,
+        lowPriorityHandler,
+        eventEmitter,
+      ],
+      dependencies: { eventEmitter },
+      async init(_, { eventEmitter }) {
+        // Test with value <= 10 (no propagation stop)
+        await eventEmitter(5);
+        
+        // Test with value > 10 (propagation stop)
+        await eventEmitter(15);
+      },
+    });
+
+    await run(app);
+
+    // Verify both handlers executed for first event (value=5)
+    expect(eventHandlerExecutions.filter(e => e === "high-priority-executed")).toHaveLength(2);
+    expect(eventHandlerExecutions.filter(e => e === "low-priority-executed")).toHaveLength(1);
+    
+    // Verify propagation was stopped for second event (value=15)
+    expect(eventHandlerExecutions.filter(e => e === "propagation-stopped")).toHaveLength(1);
+    
+    // The low priority handler should NOT have run for the second event due to stopped propagation
+    // So it should only appear once (from the first event where propagation was not stopped)
+  });
+
+  it("should support global event listeners with both global and local middleware", async () => {
+    const middlewareExecutions: string[] = [];
+    const eventHandlerExecutions: string[] = [];
+
+    // Custom event to emit
+    const testEvent = defineEvent<{ message: string }>({
+      id: "test.globalMiddlewareEvent",
+      meta: {
+        title: "Global Middleware Test Event",
+        description: "Test event for global middleware verification",
+        tags: ["test", "global"],
+      },
+    });
+
+    // Global middleware that should be applied everywhere
+    const globalMiddleware = defineMiddleware({
+      id: "global.middleware",
+      run: async ({ next, task }) => {
+        const taskId = task?.definition?.id || "unknown";
+        middlewareExecutions.push(`global-middleware-before:${String(taskId)}`);
+        const result = await next(task?.input);
+        middlewareExecutions.push(`global-middleware-after:${String(taskId)}`);
+        return result;
+      },
+    }).everywhere(); // Make it global
+
+    // Local middleware specific to certain tasks
+    const localMiddleware = defineMiddleware({
+      id: "local.middleware",
+      run: async ({ next, task }) => {
+        const taskId = task?.definition?.id || "unknown";
+        middlewareExecutions.push(`local-middleware-before:${String(taskId)}`);
+        const result = await next(task?.input);
+        middlewareExecutions.push(`local-middleware-after:${String(taskId)}`);
+        return result;
+      },
+    });
+
+    // Global event listener task with local middleware
+    const globalEventHandler = defineTask({
+      id: "global.middleware.event.handler",
+      on: "*", // Global listener
+      middleware: [localMiddleware], // Local middleware
+      run: async (event) => {
+        if (event && event.id) {
+          eventHandlerExecutions.push(`global-handler:${event.id.toString()}`);
+          if (event.id === testEvent.id) {
+            expect(event.meta.title).toBe("Global Middleware Test Event");
+            expect(event.data.message).toBe("Hello from middleware test");
+          }
+        }
+      },
+    });
+
+    // Specific event listener task with local middleware
+    const specificEventHandler = defineTask({
+      id: "specific.middleware.event.handler",
+      on: testEvent,
+      middleware: [localMiddleware], // Local middleware
+      run: async (event) => {
+        if (event && event.id) {
+          eventHandlerExecutions.push(`specific-handler:${event.id.toString()}`);
+          expect(event.meta.title).toBe("Global Middleware Test Event");
+          expect(event.data.message).toBe("Hello from middleware test");
+        }
+      },
+    });
+
+    // Task that emits the test event
+    const eventEmitter = defineTask({
+      id: "middleware.event.emitter",
+      dependencies: { testEvent },
+      middleware: [localMiddleware], // This task also has local middleware
+      run: async (_, { testEvent }) => {
+        await testEvent({ message: "Hello from middleware test" });
+        return "Event emitted";
+      },
+    });
+
+    const app = defineResource({
+      id: "app",
+      register: [
+        globalMiddleware, // Register global middleware
+        localMiddleware,
+        testEvent,
+        globalEventHandler,
+        specificEventHandler,
+        eventEmitter,
+      ],
+      dependencies: { eventEmitter },
+      async init(_, { eventEmitter }) {
+        await eventEmitter();
+      },
+    });
+
+    await run(app);
+
+    // Verify global middleware was called for global event listener
+    expect(middlewareExecutions).toContain("global-middleware-before:global.middleware.event.handler");
+    expect(middlewareExecutions).toContain("global-middleware-after:global.middleware.event.handler");
+
+    // Verify local middleware was called for global event listener
+    expect(middlewareExecutions).toContain("local-middleware-before:global.middleware.event.handler");
+    expect(middlewareExecutions).toContain("local-middleware-after:global.middleware.event.handler");
+
+    // Verify global middleware was called for specific event listener
+    expect(middlewareExecutions).toContain("global-middleware-before:specific.middleware.event.handler");
+    expect(middlewareExecutions).toContain("global-middleware-after:specific.middleware.event.handler");
+
+    // Verify local middleware was called for specific event listener
+    expect(middlewareExecutions).toContain("local-middleware-before:specific.middleware.event.handler");
+    expect(middlewareExecutions).toContain("local-middleware-after:specific.middleware.event.handler");
+
+    // Verify global middleware was called for event emitter task
+    expect(middlewareExecutions).toContain("global-middleware-before:middleware.event.emitter");
+    expect(middlewareExecutions).toContain("global-middleware-after:middleware.event.emitter");
+
+    // Verify local middleware was called for event emitter task
+    expect(middlewareExecutions).toContain("local-middleware-before:middleware.event.emitter");
+    expect(middlewareExecutions).toContain("local-middleware-after:middleware.event.emitter");
+
+    // Verify event handlers were executed
+    expect(eventHandlerExecutions).toContain("global-handler:test.globalMiddlewareEvent");
+    expect(eventHandlerExecutions).toContain("specific-handler:test.globalMiddlewareEvent");
+
+    // Verify global listeners also handle other events (like global events themselves)
+    expect(eventHandlerExecutions.some(exec => 
+      exec.includes("global-handler:") && exec.includes("beforeInit")
+    )).toBe(true);
   });
 });

--- a/src/__tests__/globalEvents.test.ts
+++ b/src/__tests__/globalEvents.test.ts
@@ -1,5 +1,10 @@
 import { globalEvents } from "../globals/globalEvents";
-import { defineTask, defineResource, defineMiddleware, defineEvent } from "../define";
+import {
+  defineTask,
+  defineResource,
+  defineMiddleware,
+  defineEvent,
+} from "../define";
 import { run } from "../run";
 
 describe("Global Events", () => {
@@ -174,7 +179,9 @@ describe("Global Events", () => {
       middleware: [testMiddleware],
       run: async (event) => {
         if (event && event.id) {
-          eventHandlerExecutions.push(`specific-handler:${event.id.toString()}`);
+          eventHandlerExecutions.push(
+            `specific-handler:${event.id.toString()}`
+          );
           expect(event.meta.title).toBe("Test Event");
           expect(event.data.message).toBe("Hello from custom event");
         }
@@ -209,21 +216,34 @@ describe("Global Events", () => {
     await run(app);
 
     // Verify middleware was called for global event listener
-    expect(middlewareExecutions).toContain("middleware-before:global.event.handler");
-    expect(middlewareExecutions).toContain("middleware-after:global.event.handler");
+    expect(middlewareExecutions).toContain(
+      "middleware-before:global.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "middleware-after:global.event.handler"
+    );
 
     // Verify middleware was called for specific event listener
-    expect(middlewareExecutions).toContain("middleware-before:specific.event.handler");
-    expect(middlewareExecutions).toContain("middleware-after:specific.event.handler");
+    expect(middlewareExecutions).toContain(
+      "middleware-before:specific.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "middleware-after:specific.event.handler"
+    );
 
     // Verify event handlers were executed
     expect(eventHandlerExecutions).toContain("global-handler:test.customEvent");
-    expect(eventHandlerExecutions).toContain("specific-handler:test.customEvent");
+    expect(eventHandlerExecutions).toContain(
+      "specific-handler:test.customEvent"
+    );
 
     // Verify global listeners also handle other events (like global events themselves)
-    expect(eventHandlerExecutions.some(exec => 
-      exec.includes("global-handler:") && exec.includes("beforeInit")
-    )).toBe(true);
+    expect(
+      eventHandlerExecutions.some(
+        (exec) =>
+          exec.includes("global-handler:") && exec.includes("beforeInit")
+      )
+    ).toBe(true);
   });
 
   it("should support stopPropagation in event listeners", async () => {
@@ -244,9 +264,11 @@ describe("Global Events", () => {
       listenerOrder: -100, // Higher priority (runs first)
       run: async (event) => {
         eventHandlerExecutions.push("high-priority-executed");
-        
+
         if (event && event.data && event.data.value > 10) {
+          expect(event.isPropagationStopped()).toBe(false);
           event.stopPropagation();
+          expect(event.isPropagationStopped()).toBe(true);
           eventHandlerExecutions.push("propagation-stopped");
         }
       },
@@ -283,7 +305,7 @@ describe("Global Events", () => {
       async init(_, { eventEmitter }) {
         // Test with value <= 10 (no propagation stop)
         await eventEmitter(5);
-        
+
         // Test with value > 10 (propagation stop)
         await eventEmitter(15);
       },
@@ -292,12 +314,18 @@ describe("Global Events", () => {
     await run(app);
 
     // Verify both handlers executed for first event (value=5)
-    expect(eventHandlerExecutions.filter(e => e === "high-priority-executed")).toHaveLength(2);
-    expect(eventHandlerExecutions.filter(e => e === "low-priority-executed")).toHaveLength(1);
-    
+    expect(
+      eventHandlerExecutions.filter((e) => e === "high-priority-executed")
+    ).toHaveLength(2);
+    expect(
+      eventHandlerExecutions.filter((e) => e === "low-priority-executed")
+    ).toHaveLength(1);
+
     // Verify propagation was stopped for second event (value=15)
-    expect(eventHandlerExecutions.filter(e => e === "propagation-stopped")).toHaveLength(1);
-    
+    expect(
+      eventHandlerExecutions.filter((e) => e === "propagation-stopped")
+    ).toHaveLength(1);
+
     // The low priority handler should NOT have run for the second event due to stopped propagation
     // So it should only appear once (from the first event where propagation was not stopped)
   });
@@ -363,7 +391,9 @@ describe("Global Events", () => {
       middleware: [localMiddleware], // Local middleware
       run: async (event) => {
         if (event && event.id) {
-          eventHandlerExecutions.push(`specific-handler:${event.id.toString()}`);
+          eventHandlerExecutions.push(
+            `specific-handler:${event.id.toString()}`
+          );
           expect(event.meta.title).toBe("Global Middleware Test Event");
           expect(event.data.message).toBe("Hello from middleware test");
         }
@@ -400,36 +430,67 @@ describe("Global Events", () => {
     await run(app);
 
     // Verify global middleware was called for global event listener
-    expect(middlewareExecutions).toContain("global-middleware-before:global.middleware.event.handler");
-    expect(middlewareExecutions).toContain("global-middleware-after:global.middleware.event.handler");
+    expect(middlewareExecutions).toContain(
+      "global-middleware-before:global.middleware.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "global-middleware-after:global.middleware.event.handler"
+    );
 
     // Verify local middleware was called for global event listener
-    expect(middlewareExecutions).toContain("local-middleware-before:global.middleware.event.handler");
-    expect(middlewareExecutions).toContain("local-middleware-after:global.middleware.event.handler");
+    expect(middlewareExecutions).toContain(
+      "local-middleware-before:global.middleware.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "local-middleware-after:global.middleware.event.handler"
+    );
 
     // Verify global middleware was called for specific event listener
-    expect(middlewareExecutions).toContain("global-middleware-before:specific.middleware.event.handler");
-    expect(middlewareExecutions).toContain("global-middleware-after:specific.middleware.event.handler");
+    expect(middlewareExecutions).toContain(
+      "global-middleware-before:specific.middleware.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "global-middleware-after:specific.middleware.event.handler"
+    );
 
     // Verify local middleware was called for specific event listener
-    expect(middlewareExecutions).toContain("local-middleware-before:specific.middleware.event.handler");
-    expect(middlewareExecutions).toContain("local-middleware-after:specific.middleware.event.handler");
+    expect(middlewareExecutions).toContain(
+      "local-middleware-before:specific.middleware.event.handler"
+    );
+    expect(middlewareExecutions).toContain(
+      "local-middleware-after:specific.middleware.event.handler"
+    );
 
     // Verify global middleware was called for event emitter task
-    expect(middlewareExecutions).toContain("global-middleware-before:middleware.event.emitter");
-    expect(middlewareExecutions).toContain("global-middleware-after:middleware.event.emitter");
+    expect(middlewareExecutions).toContain(
+      "global-middleware-before:middleware.event.emitter"
+    );
+    expect(middlewareExecutions).toContain(
+      "global-middleware-after:middleware.event.emitter"
+    );
 
     // Verify local middleware was called for event emitter task
-    expect(middlewareExecutions).toContain("local-middleware-before:middleware.event.emitter");
-    expect(middlewareExecutions).toContain("local-middleware-after:middleware.event.emitter");
+    expect(middlewareExecutions).toContain(
+      "local-middleware-before:middleware.event.emitter"
+    );
+    expect(middlewareExecutions).toContain(
+      "local-middleware-after:middleware.event.emitter"
+    );
 
     // Verify event handlers were executed
-    expect(eventHandlerExecutions).toContain("global-handler:test.globalMiddlewareEvent");
-    expect(eventHandlerExecutions).toContain("specific-handler:test.globalMiddlewareEvent");
+    expect(eventHandlerExecutions).toContain(
+      "global-handler:test.globalMiddlewareEvent"
+    );
+    expect(eventHandlerExecutions).toContain(
+      "specific-handler:test.globalMiddlewareEvent"
+    );
 
     // Verify global listeners also handle other events (like global events themselves)
-    expect(eventHandlerExecutions.some(exec => 
-      exec.includes("global-handler:") && exec.includes("beforeInit")
-    )).toBe(true);
+    expect(
+      eventHandlerExecutions.some(
+        (exec) =>
+          exec.includes("global-handler:") && exec.includes("beforeInit")
+      )
+    ).toBe(true);
   });
 });

--- a/src/define.ts
+++ b/src/define.ts
@@ -179,12 +179,13 @@ export function defineIndex<
 }
 
 export function defineEvent<TPayload = void>(
-  config: IEventDefinition<TPayload>
+  config?: IEventDefinition<TPayload>
 ): IEvent<TPayload> {
   const callerFilePath = getCallerFile();
+  const eventConfig = config || {};
   return {
-    ...config,
-    id: config.id || generateCallerIdFromFile(callerFilePath, "event"),
+    ...eventConfig,
+    id: eventConfig.id || generateCallerIdFromFile(callerFilePath, "event"),
     [symbols.filePath]: callerFilePath,
     [symbolEvent]: true, // This is a workaround
   };

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -309,6 +309,18 @@ export interface IEventEmission<TPayload = any> {
    * The source of the event. This can be useful for debugging.
    */
   source: string | symbol;
+  /**
+   * Metadata associated with the event definition.
+   */
+  meta: IEventMeta;
+  /**
+   * Stops propagation to remaining event listeners.
+   */
+  stopPropagation(): void;
+  /**
+   * Returns true if propagation has been stopped.
+   */
+  isPropagationStopped(): boolean;
 }
 
 export interface IMiddlewareDefinition<

--- a/src/models/EventManager.ts
+++ b/src/models/EventManager.ts
@@ -112,14 +112,25 @@ export class EventManager {
       return;
     }
 
+    let propagationStopped = false;
+
     const event: IEventEmission = {
       id: eventDefinition.id,
       data,
       timestamp: new Date(),
       source,
+      meta: eventDefinition.meta || {},
+      stopPropagation: () => {
+        propagationStopped = true;
+      },
+      isPropagationStopped: () => propagationStopped,
     };
 
     for (const listener of allListeners) {
+      if (propagationStopped) {
+        break;
+      }
+      
       if (!listener.filter || listener.filter(event)) {
         await listener.handler(event);
       }


### PR DESCRIPTION
Fixes #20 

- Added stopPropagation() opening the path
- Listeners receive now the event metas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for event listeners to stop event propagation, allowing control over which listeners are executed.
  * Event emission now provides access to event metadata.
  * `defineEvent` can now be called without arguments, providing default event configuration.
* **Documentation**
  * Added a new section explaining event propagation control using `stopPropagation()` with usage examples.
* **Tests**
  * Introduced comprehensive tests covering middleware execution, event propagation control, and combined middleware scenarios for global and specific event listeners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->