### PR TITLE
feat: introduce `override()` helper for safe component property overr…

### DIFF
--- a/src/__tests__/benchmark/task-benchmark.test.ts
+++ b/src/__tests__/benchmark/task-benchmark.test.ts
@@ -1,0 +1,132 @@
+import { defineTask, defineResource, defineMiddleware } from "../../define";
+import { run } from "../../run";
+
+// Benchmarks are environment-sensitive; keep skipped by default.
+describe("Task benchmarks - sync vs async", () => {
+  const iterations = 500;
+
+  it("compares sync vs async task execution without middleware", async () => {
+    const syncTask = defineTask<number, any>({
+      id: "bench.syncTask",
+      // Intentionally synchronous
+      run: ((n: number) => {
+        let acc = 0;
+        for (let i = 0; i < 200; i++) acc += (n + i) % 7;
+        return acc;
+      }) as any,
+    } as any);
+
+    const asyncTask = defineTask<number, Promise<number>>({
+      id: "bench.asyncTask",
+      run: async (n: number) => {
+        let acc = 0;
+        for (let i = 0; i < 200; i++) acc += (n + i) % 7;
+        return acc;
+      },
+    });
+
+    const app = defineResource({
+      id: "bench.app",
+      register: [syncTask, asyncTask],
+      dependencies: { syncTask, asyncTask },
+      async init(_, { syncTask, asyncTask }) {
+        // Warm-up
+        await asyncTask(0);
+        await syncTask(0 as any);
+
+        const syncStart = performance.now();
+        for (let i = 0; i < iterations; i++) {
+          // Note: sync path still awaited at the TaskRunner boundary
+          await syncTask(i as any);
+        }
+        const syncTime = performance.now() - syncStart;
+
+        const asyncStart = performance.now();
+        for (let i = 0; i < iterations; i++) {
+          await asyncTask(i);
+        }
+        const asyncTime = performance.now() - asyncStart;
+
+        // Log metrics for manual inspection
+        // eslint-disable-next-line no-console
+        console.log(
+          `Task benchmark (iterations=${iterations}) -> sync: ${syncTime.toFixed(
+            2
+          )}ms, async: ${asyncTime.toFixed(2)}ms`
+        );
+      },
+    });
+
+    const { dispose } = await run(app);
+    await dispose();
+  });
+
+  it("compares with a chain of pass-through middlewares", async () => {
+    const chainLength = 10;
+
+    const middlewares = Array.from({ length: chainLength }, (_, idx) =>
+      defineMiddleware({
+        id: `mw.${idx}`,
+        // Return the result of next() directly; no extra async wrapper here
+        run: ({ next }: any) => next(),
+      })
+    );
+
+    const syncTask = defineTask<number, any>({
+      id: "bench.syncTask.withMw",
+      middleware: middlewares,
+      // Intentionally synchronous
+      run: ((n: number) => {
+        let acc = 0;
+        for (let i = 0; i < 200; i++) acc += (n + i) % 7;
+        return acc;
+      }) as any,
+    } as any);
+
+    const asyncTask = defineTask<number, Promise<number>>({
+      id: "bench.asyncTask.withMw",
+      middleware: middlewares,
+      run: async (n: number) => {
+        let acc = 0;
+        for (let i = 0; i < 200; i++) acc += (n + i) % 7;
+        return acc;
+      },
+    });
+
+    const app = defineResource({
+      id: "bench.app.mw",
+      register: [...middlewares, syncTask, asyncTask],
+      dependencies: { syncTask, asyncTask },
+      async init(_, { syncTask, asyncTask }) {
+        // Warm-up
+        await asyncTask(0);
+        await syncTask(0 as any);
+
+        const iters = 5000;
+        const t0 = process.hrtime.bigint();
+        for (let i = 0; i < iters; i++) {
+          await syncTask(i as any);
+        }
+        const t1 = process.hrtime.bigint();
+        const syncNs = Number(t1 - t0);
+
+        const t2 = process.hrtime.bigint();
+        for (let i = 0; i < iters; i++) {
+          await asyncTask(i);
+        }
+        const t3 = process.hrtime.bigint();
+        const asyncNs = Number(t3 - t2);
+
+        // eslint-disable-next-line no-console
+        console.log(
+          `Task benchmark with ${chainLength} middlewares (iterations=${iters}) -> sync: ${(
+            syncNs / 1e6
+          ).toFixed(2)}ms, async: ${(asyncNs / 1e6).toFixed(2)}ms`
+        );
+      },
+    });
+
+    const { dispose } = await run(app);
+    await dispose();
+  });
+});

--- a/src/__tests__/override.test.ts
+++ b/src/__tests__/override.test.ts
@@ -1,0 +1,104 @@
+import { definitions, task, resource, middleware, override } from "..";
+
+describe("override() helper", () => {
+  it("should preserve id and override run for tasks", async () => {
+    const base = task({
+      id: "test.task",
+      run: async () => "base",
+    });
+
+    const changed = override(base, {
+      run: async () => "changed",
+      meta: { title: "Updated" },
+    });
+
+    expect(changed).not.toBe(base);
+    expect(changed.id).toBe(base.id);
+    expect(await base.run(undefined as any, {} as any)).toBe("base");
+    expect(await changed.run(undefined as any, {} as any)).toBe("changed");
+    expect(changed.meta?.title).toBe("Updated");
+  });
+
+  it("should preserve id and override init for resources", async () => {
+    const base = resource({
+      id: "test.resource",
+      init: async () => 1,
+    });
+
+    const changed = override(base, {
+      init: async () => 2,
+      meta: { description: "Updated" },
+    });
+
+    expect(changed).not.toBe(base);
+    expect(changed.id).toBe(base.id);
+    // Call the init functions directly (without runner) to validate override
+    // Signatures: init(config, deps, ctx)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const v1 = await base.init!(undefined as any, {} as any, undefined as any);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const v2 = await changed.init!(
+      undefined as any,
+      {} as any,
+      undefined as any
+    );
+    expect(v1).toBe(1);
+    expect(v2).toBe(2);
+    expect(changed.meta?.description).toBe("Updated");
+  });
+
+  it("should preserve id and override run for middleware", async () => {
+    const mw = middleware({
+      id: "test.middleware",
+      run: async ({ next }) => {
+        return next();
+      },
+    });
+
+    const changed = override(mw, {
+      run: async ({ task, next }) => {
+        const result = await next(task?.input as any);
+        return { wrapped: result } as any;
+      },
+    });
+
+    expect(changed).not.toBe(mw);
+    expect(changed.id).toBe(mw.id);
+
+    const input = {
+      task: { definition: undefined as any, input: 123 },
+      next: async () => 456,
+    } as definitions.IMiddlewareExecutionInput<any, any>;
+
+    const baseResult = await mw.run(input, {} as any, undefined as any);
+    const changedResult = await changed.run(input, {} as any, undefined as any);
+    expect(baseResult).toBe(456);
+    expect(changedResult).toEqual({ wrapped: 456 });
+  });
+
+  it("should be type-safe: cannot override id on task/resource/middleware", () => {
+    const t = task({ id: "tt", run: async () => undefined });
+    const r = resource({ id: "rr", init: async () => undefined });
+    const m = middleware({ id: "mm", run: async ({ next }) => next() });
+
+    // @ts-expect-error id cannot be overridden
+    override(t, { id: "new" });
+
+    // @ts-expect-error id cannot be overridden
+    override(r, { id: "new" });
+
+    // @ts-expect-error id cannot be overridden
+    override(m, { id: "new" });
+
+    expect(true).toBe(true);
+  });
+
+  it("should handle undefined patch (robustness)", () => {
+    const base = task({ id: "robust.task", run: async () => 1 });
+    const changed = (override as any)(base, undefined);
+
+    expect(changed).not.toBe(base);
+    expect(changed.id).toBe(base.id);
+    expect(changed.run).toBe(base.run);
+  });
+});

--- a/src/__tests__/run.overrides.test.ts
+++ b/src/__tests__/run.overrides.test.ts
@@ -4,6 +4,7 @@ import {
   defineResource,
   defineEvent,
   defineMiddleware,
+  override,
 } from "../define";
 import { Errors } from "../errors";
 import { run } from "../run";
@@ -16,8 +17,7 @@ describe("run.overrides", () => {
       run: async () => "Task executed",
     });
 
-    const override = defineTask({
-      id: "task",
+    const overrideTask = override(task, {
       run: async () => "Task overridden",
     });
 
@@ -27,7 +27,7 @@ describe("run.overrides", () => {
       dependencies: {
         task,
       },
-      overrides: [override],
+      overrides: [overrideTask],
       async init(_, deps) {
         return await deps.task();
       },
@@ -43,15 +43,14 @@ describe("run.overrides", () => {
       run: async () => "Task executed",
     });
 
-    const override = defineTask({
-      id: "task",
+    const overrideTask = override(task, {
       run: async () => "Task overridden",
     });
 
     const middle = defineResource({
       id: "app",
       register: [task],
-      overrides: [override],
+      overrides: [overrideTask],
     });
 
     const root = defineResource({
@@ -73,15 +72,14 @@ describe("run.overrides", () => {
       run: async () => "Task executed",
     });
 
-    const override = defineTask({
-      id: "task",
+    const overrideTask = override(task, {
       run: async () => "Task overridden",
     });
 
     const middle = defineResource<{ test: string }>({
       id: "app",
       register: [task],
-      overrides: [override],
+      overrides: [overrideTask],
     });
 
     const root = defineResource({
@@ -103,8 +101,7 @@ describe("run.overrides", () => {
       run: async () => "Task executed",
     });
 
-    const override = defineTask({
-      id: "task",
+    const overrideTask = override(task, {
       run: async () => "Task overridden",
     });
 
@@ -112,10 +109,9 @@ describe("run.overrides", () => {
       id: "resource",
     });
 
-    const resourceOverride = {
-      ...resource,
-      overrides: [override],
-    };
+    const resourceOverride = override(resource, {
+      overrides: [overrideTask],
+    });
 
     const middle = defineResource({
       id: "app",
@@ -142,8 +138,7 @@ describe("run.overrides", () => {
       run: async () => "Task executed",
     });
 
-    const override = defineTask({
-      id: "task",
+    const overrideTask = override(task, {
       run: async () => "Task overridden",
     });
 
@@ -153,7 +148,7 @@ describe("run.overrides", () => {
 
     const resourceOverride: definitions.IResource<any> = {
       ...resource,
-      overrides: [override],
+      overrides: [overrideTask],
       async init(config: { test: string }) {
         return "Resource init";
       },
@@ -186,8 +181,7 @@ describe("run.overrides", () => {
       },
     });
 
-    const override = defineMiddleware({
-      id: "middleware",
+    const middlewareOverride = override(middleware, {
       run: async ({ next }) => {
         return `Override: ${await next()}`;
       },
@@ -203,7 +197,7 @@ describe("run.overrides", () => {
       id: "resource",
       register: [middleware, task],
       dependencies: { task },
-      overrides: [override],
+      overrides: [middlewareOverride],
       async init(_, deps) {
         return deps.task();
       },

--- a/src/define.ts
+++ b/src/define.ts
@@ -266,3 +266,32 @@ export function isEvent(definition: any): definition is IEvent {
 export function isMiddleware(definition: any): definition is IMiddleware {
   return definition && definition[symbols.middleware];
 }
+
+/**
+ * Override helper that preserves the original `id` and returns the same type.
+ * You can override any property except `id`.
+ */
+export function override<T extends ITask<any, any, any, any>>(
+  base: T,
+  patch: Omit<Partial<T>, "id">
+): T;
+export function override<T extends IResource<any, any, any, any>>(
+  base: T,
+  patch: Omit<Partial<T>, "id">
+): T;
+export function override<T extends IMiddleware<any, any>>(
+  base: T,
+  patch: Omit<Partial<T>, "id">
+): T;
+export function override(
+  base: ITask | IResource,
+  patch: Record<string | symbol, unknown>
+): ITask | IResource {
+  const { id: _ignored, ...rest } = (patch || {}) as any;
+  // Ensure we never change the id, and merge overrides last
+  return {
+    ...(base as any),
+    ...rest,
+    id: (base as any).id,
+  } as any;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   defineEvent,
   defineMiddleware,
   defineIndex,
+  override,
 } from "./define";
 import { createContext } from "./context";
 import { globalEvents } from "./globals/globalEvents";
@@ -24,6 +25,7 @@ export {
   defineEvent as event,
   defineMiddleware as middleware,
   defineIndex as index,
+  override,
   run,
   createContext,
 };


### PR DESCRIPTION
…ides

Added a new `override()` function that allows users to safely override properties of tasks, resources, and middleware while preserving the original `id`. Updated documentation to include usage examples and notes on the API. Enhanced tests to validate the new functionality.