### PR TITLE
[WIP] v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ const myResource = resource({ ... });
 - `myResource.events.beforeInit` - Fires before the resource initializes
 - `myResource.events.afterInit` - Fires after the resource initializes
 - `myResource.events.onError` - Fires when the resource initialization fails
+- `myMiddleware.events.beforeRun` - Fires before the middleware runs.
+- `myMiddleware.events.afterRun` - Fires after the middleware has executed successfuly.
+- `myMiddleware.events.onError` - Fires after the middleware has executed successfuly.
 
 Each event has its own utilities and functions.
 
@@ -286,6 +289,9 @@ The framework comes with its own set of events that fire during the lifecycle. T
 - `globals.resources.beforeInit` - "Initializing a resource"
 - `globals.resources.afterInit` - "Resource is ready"
 - `globals.resources.onError` - "Resource initialization failed"
+- `globals.middleware.beforeRun` - "Hey, I'm about to run this middleware"
+- `globals.middleware.afterRun` - "Middleware run completed, I'm applying the next next()"
+- `globals.middleware.onError` - "Oops, something went wrong"
 
 ```typescript
 const taskLogger = task({

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/bluelibs/bluelibs"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --project tsconfig.build.json",
     "clean": "rm -rf dist",
     "watch": "tsc -w",
     "test": "jest --verbose --runInBand",

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,4 +1,4 @@
-import { createContext, task, run, resource } from "../index";
+import { createContext, task, run, resource, Store } from "../index";
 import { ContextError } from "../context";
 
 describe("Context System", () => {
@@ -16,6 +16,7 @@ describe("Context System", () => {
       await expect(run(r)).resolves.toEqual({
         value: { id: "1" },
         dispose: expect.any(Function),
+        store: expect.any(Store),
       });
     });
   });
@@ -39,6 +40,7 @@ describe("Context System", () => {
       await expect(run(r)).resolves.toEqual({
         value: "ok",
         dispose: expect.any(Function),
+        store: expect.any(Store),
       });
     });
   });

--- a/src/__tests__/globals/cache.middleware.test.ts
+++ b/src/__tests__/globals/cache.middleware.test.ts
@@ -344,7 +344,7 @@ describe("Caching System", () => {
           id: "app",
           register: [cacheResource, cacheMiddleware, testTask],
           dependencies: { testTask, cache: cacheResource },
-          async init(_, { testTask, cache }) {
+          async init(_: void, { testTask, cache }) {
             const firstRun = await testTask();
             const secondRun = await testTask(); // Should be cached
 
@@ -651,17 +651,17 @@ describe("Caching System", () => {
         run: async () => "test",
       });
 
-      const result = await run(
-        defineResource({
-          id: "app",
-          register: [disposableCacheResource, cacheMiddleware, testTask],
-          dependencies: { testTask, cache: disposableCacheResource },
-          async init(_, { testTask, cache }) {
-            await testTask();
-            return cache;
-          },
-        })
-      );
+      const app = defineResource({
+        id: "app",
+        register: [disposableCacheResource, cacheMiddleware, testTask],
+        dependencies: { testTask, cache: disposableCacheResource },
+        async init(_, { testTask, cache }) {
+          await testTask();
+          return cache;
+        },
+      });
+
+      const result = await run(app);
 
       // Manually dispose to trigger cleanup
       await result.dispose();

--- a/src/__tests__/globals/requireContext.middleware.test.ts
+++ b/src/__tests__/globals/requireContext.middleware.test.ts
@@ -34,7 +34,11 @@ describe("requireContextMiddleware", () => {
 
   it("throws ContextError when the context has not been provided", async () => {
     // Arrange → a context whose `use` returns undefined, simulating missing provider
-    const fakeContext = createFakeContext(() => undefined);
+    const fakeContext = createFakeContext(() => {
+      throw new ContextError(
+        "Context not available. Did you forget to provide the context via ContextName.provide()?"
+      );
+    });
     const next = jest.fn();
 
     // Act & Assert

--- a/src/__tests__/run.anonymous.test.ts
+++ b/src/__tests__/run.anonymous.test.ts
@@ -73,7 +73,7 @@ describe("Anonymous Components", () => {
 
       expect(typeof anonymousTask.events.afterRun.id).toBe("symbol");
       expect(anonymousTask.events.afterRun.id.toString()).toContain(
-        "anonymous-task.events.afterRun"
+        "anonymous.test.task.events.afterRun"
       );
 
       const app = defineResource({
@@ -247,7 +247,7 @@ describe("Anonymous Components", () => {
 
       expect(typeof anonymousResource.events.afterInit.id).toBe("symbol");
       expect(anonymousResource.events.afterInit.id.toString()).toContain(
-        "anonymous-resource.events.afterInit"
+        "anonymous.test.resource.events.afterInit"
       );
 
       const app = defineResource({

--- a/src/__tests__/run.test.ts
+++ b/src/__tests__/run.test.ts
@@ -694,6 +694,16 @@ describe("run", () => {
     expect(mockFn).toHaveBeenCalled();
   });
 
+  it("should be able to run a resource with a config", async () => {
+    const testResource = defineResource({
+      id: "test.resource",
+      init: async (config: { prefix: string }) => `${config.prefix} World!`,
+    });
+
+    const result = await run(testResource.with({ prefix: "Hello," }));
+    expect(result.value).toBe("Hello, World!");
+  });
+
   describe("disposal", () => {
     it("should be able to dispose of a resource", async () => {
       const disposeFn = jest.fn();

--- a/src/__tests__/tags.test.ts
+++ b/src/__tests__/tags.test.ts
@@ -33,6 +33,21 @@ describe("Configurable Tags", () => {
       expect(typeof simpleTag.with).toBe("function");
       expect(typeof simpleTag.extract).toBe("function");
     });
+
+    it("should work with validation schema", () => {
+      const simpleTag = defineTag<{ value: string }>({
+        id: "simple.tag",
+        configSchema: {
+          parse: (input) => {
+            throw new Error("Validation Error");
+          },
+        },
+      });
+
+      expect(() => simpleTag.with({ value: 123 as unknown as string })).toThrow(
+        "Validation Error"
+      );
+    });
   });
 
   describe("Tag Configuration with .with()", () => {

--- a/src/define.ts
+++ b/src/define.ts
@@ -470,9 +470,18 @@ export function defineTag<TConfig = void, TEnforceContract = void>(
 
   return {
     id,
+    meta: definition.meta,
     with(tagConfig: TConfig) {
+      if (this.configSchema) {
+        try {
+          tagConfig = this.configSchema.parse(tagConfig);
+        } catch (error) {
+          throw new ValidationError("Tag config", this.id, error as Error);
+        }
+      }
       return {
         id,
+        meta: definition.meta,
         tag: this,
         config: tagConfig as any,
       } as ITagWithConfig<TConfig>;

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -309,6 +309,11 @@ export type AfterInitEventPayload<TConfig, TValue> = {
   value: TValue;
 };
 
+export type MiddlewareBeforeRunEventPayload =
+  MiddlewareInputMaybeTaskOrResource;
+
+export type MiddlewareAfterRunEventPayload = MiddlewareInputMaybeTaskOrResource;
+
 /**
  * This is the response after the definition has been prepared. TODO: better naming?
  */
@@ -531,6 +536,7 @@ export interface IMiddlewareDefinition<
   configSchema?: IValidationSchema<TConfig>;
   /**
    * The middleware body, called with task/resource execution input.
+   * The response of the middleware should be void, but we allow any to be returned for convenience.
    */
   run: (
     input: IMiddlewareExecutionInput,
@@ -539,6 +545,22 @@ export interface IMiddlewareDefinition<
   ) => Promise<any>;
   meta?: IMiddlewareMeta;
 }
+
+export type MiddlewareInputMaybeTaskOrResource =
+  | {
+      task: {
+        definition: ITask<any, any, any, any>;
+        input: any;
+      };
+      resource?: never;
+    }
+  | {
+      resource: {
+        definition: IResource<any, any, any, any, any>;
+        config: any;
+      };
+      task?: never;
+    };
 
 export interface IMiddleware<
   TConfig = any,
@@ -566,6 +588,11 @@ export interface IMiddleware<
   with: (config: TConfig) => IMiddlewareConfigured<TConfig, TDependencies>;
   [symbolFilePath]: string;
   [symbolMiddleware]: true;
+  events: {
+    beforeRun: IEvent<MiddlewareBeforeRunEventPayload>;
+    afterRun: IEvent<MiddlewareAfterRunEventPayload>;
+    onError: IEvent<OnErrorEventPayload & MiddlewareInputMaybeTaskOrResource>;
+  };
 }
 
 export interface IMiddlewareConfigured<

--- a/src/defs.ts
+++ b/src/defs.ts
@@ -76,6 +76,8 @@ export const symbolIndexResource: unique symbol = Symbol(
 
 export interface ITagDefinition<TConfig = void, TEnforceContract = void> {
   id: string | symbol;
+  meta?: ITagMeta;
+  configSchema?: IValidationSchema<TConfig>;
 }
 
 /**
@@ -153,6 +155,7 @@ export interface ITaskMeta extends IMeta {}
 export interface IResourceMeta extends IMeta {}
 export interface IEventMeta extends IMeta {}
 export interface IMiddlewareMeta extends IMeta {}
+export interface ITagMeta extends Omit<IMeta, "tags"> {}
 
 /**
  * A mapping of dependency keys to Runner definitions. Used in `dependencies`

--- a/src/globals/globalEvents.ts
+++ b/src/globals/globalEvents.ts
@@ -1,6 +1,18 @@
 import { defineEvent } from "../define";
-import { ITask, IResource, IEvent } from "../defs";
+import {
+  ITask,
+  IResource,
+  IEvent,
+  MiddlewareBeforeRunEventPayload,
+  OnErrorEventPayload,
+  MiddlewareAfterRunEventPayload,
+  IMiddleware,
+  MiddlewareInputMaybeTaskOrResource,
+} from "../defs";
 import { ILog } from "../models/Logger";
+import { globalTags } from "./globalTags";
+
+const systemTag = globalTags.system;
 
 export const globalEvents = {
   beforeInit: defineEvent({
@@ -9,7 +21,7 @@ export const globalEvents = {
       title: "Before Initialization",
       description:
         "Triggered before any resource or system-wide initialization occurs.",
-      tags: ["system"],
+      tags: [systemTag],
     },
   }),
   afterInit: defineEvent({
@@ -18,7 +30,7 @@ export const globalEvents = {
       title: "After Initialization",
       description:
         "Fired after the system or resource initialization is completed.",
-      tags: ["system"],
+      tags: [systemTag],
     },
   }),
   log: defineEvent<ILog>({
@@ -26,7 +38,7 @@ export const globalEvents = {
     meta: {
       title: "Log Event",
       description: "Used to log events and messages across the system.",
-      tags: ["system"],
+      tags: [systemTag],
     },
   }),
   tasks: {
@@ -39,7 +51,7 @@ export const globalEvents = {
         title: "Before Task Execution",
         description:
           "Triggered before a task starts running, providing access to the input data.",
-        tags: ["system"],
+        tags: [systemTag],
       },
     }),
     afterRun: defineEvent<{
@@ -53,7 +65,7 @@ export const globalEvents = {
         title: "After Task Execution",
         description:
           "Fired after a task has completed, providing both the input and output data.",
-        tags: ["system"],
+        tags: [systemTag],
       },
     }),
     onError: defineEvent<{
@@ -66,7 +78,7 @@ export const globalEvents = {
         title: "Task Error",
         description:
           "Triggered when an error occurs during task execution. Allows error suppression.",
-        tags: ["system"],
+        tags: [systemTag],
       },
     }),
   },
@@ -80,7 +92,7 @@ export const globalEvents = {
         title: "Before Resource Initialization",
         description:
           "Fired before a resource is initialized, with access to the configuration.",
-        tags: ["system"],
+        tags: [systemTag],
       },
     }),
     afterInit: defineEvent<{
@@ -93,7 +105,7 @@ export const globalEvents = {
         title: "After Resource Initialization",
         description:
           "Fired after a resource has been initialized, providing the final value.",
-        tags: ["system"],
+        tags: [systemTag],
       },
     }),
     onError: defineEvent<{
@@ -106,7 +118,46 @@ export const globalEvents = {
         title: "Resource Error",
         description:
           "Triggered when an error occurs during resource initialization. Allows error suppression.",
-        tags: ["system"],
+        tags: [systemTag],
+      },
+    }),
+  },
+  middlewares: {
+    beforeRun: defineEvent<
+      MiddlewareBeforeRunEventPayload & {
+        middleware: IMiddleware;
+      }
+    >({
+      id: "globals.events.middleware.beforeRun",
+      meta: {
+        title: "Before Middleware Run",
+        description: "Triggered before a middleware runs.",
+        tags: [systemTag],
+      },
+    }),
+    afterRun: defineEvent<
+      MiddlewareAfterRunEventPayload & {
+        middleware: IMiddleware;
+      } & MiddlewareInputMaybeTaskOrResource
+    >({
+      id: "globals.events.middleware.afterRun",
+      meta: {
+        title: "After Middleware Run",
+        description: "Triggered after a middleware runs.",
+        tags: [systemTag],
+      },
+    }),
+    onError: defineEvent<
+      OnErrorEventPayload & {
+        middleware: IMiddleware;
+      } & MiddlewareInputMaybeTaskOrResource
+    >({
+      id: "globals.events.middleware.onError",
+      meta: {
+        title: "Middleware Error",
+        description:
+          "Triggered when an error occurs during middleware execution. Allows error suppression.",
+        tags: [systemTag],
       },
     }),
   },
@@ -122,4 +173,7 @@ export const globalEventsArray = [
   globalEvents.resources.beforeInit,
   globalEvents.resources.afterInit,
   globalEvents.resources.onError,
+  globalEvents.middlewares.beforeRun,
+  globalEvents.middlewares.afterRun,
+  globalEvents.middlewares.onError,
 ];

--- a/src/globals/globalResources.ts
+++ b/src/globals/globalResources.ts
@@ -5,6 +5,9 @@ import { Store } from "../models/Store";
 import { TaskRunner } from "../models/TaskRunner";
 import { cacheResource } from "./middleware/cache.middleware";
 import { queueResource } from "./resources/queue.resource";
+import { globalTags } from "./globalTags";
+
+const systemTag = globalTags.system;
 
 const store = defineResource({
   id: "globals.resources.store",
@@ -13,7 +16,7 @@ const store = defineResource({
     title: "Store",
     description:
       "A global store that can be used to store and retrieve tasks, resources, events and middleware",
-    tags: ["internal"],
+    tags: [systemTag],
   },
 });
 
@@ -26,7 +29,7 @@ export const globalResources = {
       title: "Event Manager",
       description:
         "Manages all events and event listeners. This is meant to be used internally for most use-cases.",
-      tags: ["internal"],
+      tags: [systemTag],
     },
   }),
   taskRunner: defineResource({
@@ -36,13 +39,14 @@ export const globalResources = {
       title: "Task Runner",
       description:
         "Manages the execution of tasks and task dependencies. This is meant to be used internally for most use-cases.",
-      tags: ["internal"],
+      tags: [systemTag],
     },
   }),
   logger: defineResource({
     id: "globals.resources.logger",
     init: async (logger: Logger) => logger,
     meta: {
+      // We skip system tag for logger because it's part of the utility toolkit.
       title: "Logger",
       description:
         "Logs all events and errors. This is meant to be used internally for most use-cases. Emits a globals.log event for each log.",

--- a/src/globals/globalTags.ts
+++ b/src/globals/globalTags.ts
@@ -1,0 +1,14 @@
+import { defineTag } from "../define";
+
+export const globalTags = {
+  system: defineTag<{
+    metadata?: Record<string, any>;
+  }>({
+    id: "globals.tags.system",
+    meta: {
+      title: "System",
+      description:
+        "System-wide tags. Used for filtering out noise when you're focusing on your application.",
+    },
+  }),
+};

--- a/src/globals/middleware/requireContext.middleware.ts
+++ b/src/globals/middleware/requireContext.middleware.ts
@@ -18,12 +18,9 @@ export const requireContextMiddleware = defineMiddleware({
       );
     }
 
+    // This will throw if the context is not available
     const ctx = config.context.use();
-    if (!ctx) {
-      throw new ContextError(
-        "Context not available. Did you forget to provide the context via ContextName.provide()?"
-      );
-    }
+
     if (task) {
       return next(task.input);
     }

--- a/src/globals/resources/debug.resource.ts
+++ b/src/globals/resources/debug.resource.ts
@@ -1,0 +1,28 @@
+import { globals } from "../..";
+import { defineResource } from "../../define";
+import { debugConfig } from "./debug/debugConfig.resource";
+import { DebugFriendlyConfig } from "./debug/types";
+import { globalEventListener } from "./debug/globalEventListener.task";
+import { middlewareBeforeRunListener } from "./debug/middlewareBeforeRun.task";
+import { middlewareAfterRunListener } from "./debug/middlewareAfterRun.task";
+import { taskOnErrorListener } from "./debug/onErrorListeners.task";
+import { resourceOnErrorListener } from "./debug/onErrorListeners.task";
+import { tasksAndResourcesTrackerMiddleware } from "./debug/executionTracker.middleware";
+
+export const debugResource = defineResource({
+  id: "globals.resources.debug",
+  register: (config: DebugFriendlyConfig) => [
+    debugConfig.with(config),
+    tasksAndResourcesTrackerMiddleware.everywhere(),
+    globalEventListener,
+    middlewareBeforeRunListener,
+    middlewareAfterRunListener,
+    taskOnErrorListener,
+    resourceOnErrorListener,
+  ],
+  meta: {
+    title: "Debug",
+    description: "Debug resource. This is used to debug the system.",
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/debugConfig.resource.ts
+++ b/src/globals/resources/debug/debugConfig.resource.ts
@@ -1,0 +1,23 @@
+import { defineResource } from "../../../define";
+import { DebugConfig, DebugFriendlyConfig } from "./types";
+import { globalTags } from "../../../globals/globalTags";
+
+export const debugConfig = defineResource({
+  id: "globals.resources.debug.config",
+  meta: {
+    title: "Debug Config",
+    description: "Debug config. This is used to debug the system.",
+    tags: [globalTags.system],
+  },
+  init: async (config: DebugFriendlyConfig) => {
+    let finalConfig: DebugConfig = {
+      verbosity: "normal",
+    };
+    if (typeof config === "object") {
+      finalConfig.verbosity = config.verbosity;
+    }
+    return {
+      isVerbose: finalConfig.verbosity === "verbose",
+    };
+  },
+});

--- a/src/globals/resources/debug/executionTracker.middleware.ts
+++ b/src/globals/resources/debug/executionTracker.middleware.ts
@@ -1,0 +1,46 @@
+import { defineMiddleware } from "../../../define";
+import { globals } from "../../..";
+import { safeStringify } from "./utils";
+import { debugConfig } from "./debugConfig.resource";
+
+export const tasksAndResourcesTrackerMiddleware = defineMiddleware({
+  id: "globals.debug.middlewares.tasksAndResourcesTracker",
+  dependencies: {
+    logger: globals.resources.logger,
+    debugConfig,
+  },
+  run: async ({ task, resource, next }, { logger }) => {
+    const start = Date.now();
+    if (task) {
+      logger.info(
+        `[task] ${String(task.definition.id)} with input: \n${safeStringify(
+          task.input
+        )}`
+      );
+      const result = await next(task.input);
+      const duration = Date.now() - start;
+      logger.info(
+        `[task] ${String(
+          task.definition.id
+        )} completed with result:\n ${safeStringify(result)} in ${duration}ms`
+      );
+    }
+    if (resource) {
+      logger.info(
+        `[resource] ${String(
+          resource.definition.id
+        )} with config: ${safeStringify(resource.config)}`
+      );
+      const result = await next();
+      const duration = Date.now() - start;
+      logger.info(
+        `[resource] ${String(
+          resource.definition.id
+        )} initialized with result: ${safeStringify(result)} in ${duration}ms`
+      );
+    }
+  },
+  meta: {
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/globalEventListener.task.ts
+++ b/src/globals/resources/debug/globalEventListener.task.ts
@@ -1,0 +1,26 @@
+import { defineTask } from "../../../define";
+import { globals } from "../../../";
+import { safeStringify } from "./utils";
+
+export const globalEventListener = defineTask({
+  id: "globals.debug.tasks.globalEventListener",
+  on: "*",
+  dependencies: {
+    logger: globals.resources.logger,
+  },
+  run: async (event, { logger }) => {
+    const systemTag = globals.tags.system.extract(event);
+    if (systemTag) {
+      return;
+    }
+
+    logger.info(
+      `[event] ${String(event.id)} with payload: \n${safeStringify(event.data)}`
+    );
+  },
+  meta: {
+    title: "Non-system Event Logger",
+    description: "Logs all non-system events.",
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/middlewareAfterRun.task.ts
+++ b/src/globals/resources/debug/middlewareAfterRun.task.ts
@@ -1,0 +1,27 @@
+import { globals } from "../../..";
+import { defineTask } from "../../../define";
+
+export const middlewareAfterRunListener = defineTask({
+  id: "globals.debug.tasks.middlewareAfterRunListener",
+  on: globals.events.middlewares.afterRun,
+  dependencies: {
+    logger: globals.resources.logger,
+  },
+  run: async (event, { logger }) => {
+    const data = event.data;
+    const context = data.task ? "task" : "resource";
+    const id = data.task
+      ? data.task.definition.id
+      : data.resource.definition.id;
+    const middlewareId = event.data.middleware.id;
+
+    logger.info(
+      `[middleware][${context}] ${String(
+        middlewareId
+      )} finished wrapping ${String(id)}`
+    );
+  },
+  meta: {
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/middlewareBeforeRun.task.ts
+++ b/src/globals/resources/debug/middlewareBeforeRun.task.ts
@@ -1,0 +1,28 @@
+import { defineTask } from "../../../define";
+import { globalEvents } from "../../../globals/globalEvents";
+import { globals } from "../../..";
+
+export const middlewareBeforeRunListener = defineTask({
+  id: "globals.debug.tasks.middlewareBeforeRunListener",
+  on: globalEvents.middlewares.beforeRun,
+  dependencies: {
+    logger: globals.resources.logger,
+  },
+  run: async (event, { logger }) => {
+    const data = event.data;
+    const context = data.task ? "task" : "resource";
+    const id = data.task
+      ? data.task.definition.id
+      : data.resource.definition.id;
+    const middlewareId = event.data.middleware.id;
+
+    logger.info(
+      `[middleware][${context}] ${String(
+        middlewareId
+      )} starting wrapping ${String(id)}`
+    );
+  },
+  meta: {
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/onErrorListeners.task.ts
+++ b/src/globals/resources/debug/onErrorListeners.task.ts
@@ -1,0 +1,40 @@
+import { defineTask } from "../../../define";
+import { globals } from "../../..";
+
+export const taskOnErrorListener = defineTask({
+  id: "globals.debug.tasks.taskOnErrorListener",
+  on: globals.events.tasks.onError,
+  dependencies: {
+    logger: globals.resources.logger,
+  },
+  run: async (event, { logger }) => {
+    logger.error(
+      `[task] ${String(event.id)} errored out: ${event.data.error.toString()}`
+    );
+  },
+  meta: {
+    title: "Task On Error Listener",
+    description: "Logs all task on error events.",
+    tags: [globals.tags.system],
+  },
+});
+
+export const resourceOnErrorListener = defineTask({
+  id: "globals.debug.tasks.resourceOnErrorListener",
+  on: globals.events.resources.onError,
+  dependencies: {
+    logger: globals.resources.logger,
+  },
+  run: async (event, { logger }) => {
+    logger.error(
+      `[resource] ${String(
+        event.id
+      )} errored out: ${event.data.error.toString()}`
+    );
+  },
+  meta: {
+    title: "Resource On Error Listener",
+    description: "Logs all resource on error events.",
+    tags: [globals.tags.system],
+  },
+});

--- a/src/globals/resources/debug/types.ts
+++ b/src/globals/resources/debug/types.ts
@@ -1,0 +1,5 @@
+export type DebugConfig = {
+  verbosity: "normal" | "verbose";
+};
+
+export type DebugFriendlyConfig = boolean | DebugConfig;

--- a/src/globals/resources/debug/utils.ts
+++ b/src/globals/resources/debug/utils.ts
@@ -1,0 +1,7 @@
+export const safeStringify = (value: any) => {
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { createContext } from "./context";
 import { globalEvents } from "./globals/globalEvents";
 import { globalResources } from "./globals/globalResources";
 import { globalMiddlewares } from "./globals/globalMiddleware";
+import { globalTags } from "./globals/globalTags";
 import { run } from "./run";
 import { createTestResource } from "./testing";
 
@@ -18,6 +19,7 @@ const globals = {
   events: globalEvents,
   resources: globalResources,
   middlewares: globalMiddlewares,
+  tags: globalTags,
 };
 
 export { globals };

--- a/src/models/StoreRegistry.ts
+++ b/src/models/StoreRegistry.ts
@@ -159,6 +159,12 @@ export class StoreRegistry {
       this.storeEvent(resource.resource.events.afterInit);
       this.storeEvent(resource.resource.events.onError);
     }
+
+    for (const middleware of this.middlewares.values()) {
+      this.storeEvent(middleware.middleware.events.beforeRun);
+      this.storeEvent(middleware.middleware.events.afterRun);
+      this.storeEvent(middleware.middleware.events.onError);
+    }
   }
 
   getEverywhereMiddlewareForTasks(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "include": ["src/**/*.ts"],
+  "exclude": ["examples/**", "src/__tests__/**"],
+  "extends": "./tsconfig.json"
+}


### PR DESCRIPTION
- [ ] Middleware now dispatch lifecycle events
- [ ] Global Middleware can safely depend on resources
- [ ] Debug Resource (helpful for better logging via hooking into the system, without sacrificing performance for critical systems)
- [ ] run(app.with(config), { debug: "verbose" }) can now be accessed.